### PR TITLE
Add WIP/Ready-for-Review Labeling to PRs with an Action

### DIFF
--- a/.github/workflows/label-draft-prs.yml
+++ b/.github/workflows/label-draft-prs.yml
@@ -1,0 +1,18 @@
+name: Label Draft PRs
+
+on:
+  pull_request:
+
+jobs:
+  add_draft_label:
+    name: Add draft label to draft prs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - run: gh pr edit $NUMBER --add-label "$LABEL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABEL: WIP


### PR DESCRIPTION
This took a bit of back-and-forth, since most people seem to use
templates or scripts for this.

Fortunately, though I learned a bit...
- About the github CLI
- About permissions for actions
- About errors actions can throw

I think I should be able to add a ready_for_review job to this same
action to remove the "WIP" and put on "Ready for Review".

Then, I wonder if I should look into scripts w/ TS for adding/removing
labels?